### PR TITLE
Use wordpress helm chart 12.3.3 in tests

### DIFF
--- a/k8s_e2e_test.go
+++ b/k8s_e2e_test.go
@@ -101,7 +101,7 @@ var _ = Describe("CloudControllerManager", func() {
 
 			case wordpressName:
 				out, err = sh.Command(
-					"helm", "install", chartName, repoName, "--set", "volumePermissions.enabled=true,mariadb.volumePermissions.enabled=true", "--kubeconfig", kubeconfigFile,
+					"helm", "install", chartName, repoName, "--version=12.3.3", "--set", "volumePermissions.enabled=true,mariadb.volumePermissions.enabled=true", "--kubeconfig", kubeconfigFile,
 				).Output()
 			default:
 				err = fmt.Errorf("chart name %s not handled", chartName)


### PR DESCRIPTION
The [most current helm chart](https://artifacthub.io/packages/helm/bitnami/wordpress) (13.0.4) has a bug where the init container for the wordpress pod fails to run because there are no files inside the mounted volume, which is expected in a new installation.